### PR TITLE
extract parameter names automatically

### DIFF
--- a/src/main/java/youyihj/probezs/docs/ParameterNameMappings.java
+++ b/src/main/java/youyihj/probezs/docs/ParameterNameMappings.java
@@ -32,7 +32,7 @@ public class ParameterNameMappings {
         if (nameMappings == null) {
             load("mappings/method-parameter-names.yaml");
         }
-        String clazzName = method.getDecalredClass().getCanonicalName();
+        String clazzName = method.getDeclaredClass().getCanonicalName();
         List<Map<String, Object>> datas = nameMappings.get().get(clazzName);
 
         if (method.getParameterTypes().length == 0) {

--- a/src/main/java/youyihj/probezs/member/ExecutableData.java
+++ b/src/main/java/youyihj/probezs/member/ExecutableData.java
@@ -8,7 +8,7 @@ import java.lang.reflect.Type;
 public interface ExecutableData extends AnnotatedMember {
     String getName();
 
-    Class<?> getDecalredClass();
+    Class<?> getDeclaredClass();
 
     Class<?>[] getParameterTypes();
 

--- a/src/main/java/youyihj/probezs/member/asm/ASMMethod.java
+++ b/src/main/java/youyihj/probezs/member/asm/ASMMethod.java
@@ -14,12 +14,12 @@ import java.util.List;
  */
 public class ASMMethod extends ASMAnnotatedMember implements ExecutableData {
     private final MethodNode methodNode;
-    private final Class<?> decalredClass;
+    private final Class<?> declaredClass;
 
-    public ASMMethod(MethodNode methodNode, ASMMemberFactory memberFactory, Class<?> decalredClass) {
+    public ASMMethod(MethodNode methodNode, ASMMemberFactory memberFactory, Class<?> declaredClass) {
         super(methodNode.visibleAnnotations, memberFactory);
         this.methodNode = methodNode;
-        this.decalredClass = decalredClass;
+        this.declaredClass = declaredClass;
     }
 
     @Override
@@ -28,8 +28,8 @@ public class ASMMethod extends ASMAnnotatedMember implements ExecutableData {
     }
 
     @Override
-    public Class<?> getDecalredClass() {
-        return decalredClass;
+    public Class<?> getDeclaredClass() {
+        return declaredClass;
     }
 
     @Override

--- a/src/main/java/youyihj/probezs/member/asm/ASMMethod.java
+++ b/src/main/java/youyihj/probezs/member/asm/ASMMethod.java
@@ -1,12 +1,15 @@
 package youyihj.probezs.member.asm;
 
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.LocalVariableNode;
 import org.objectweb.asm.tree.MethodNode;
 import youyihj.probezs.member.ExecutableData;
 import youyihj.probezs.member.ParameterData;
 import youyihj.probezs.util.Arrays;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -15,6 +18,7 @@ import java.util.List;
 public class ASMMethod extends ASMAnnotatedMember implements ExecutableData {
     private final MethodNode methodNode;
     private final Class<?> declaredClass;
+    private List<String> parameterNames;
 
     public ASMMethod(MethodNode methodNode, ASMMemberFactory memberFactory, Class<?> declaredClass) {
         super(methodNode.visibleAnnotations, memberFactory);
@@ -66,11 +70,61 @@ public class ASMMethod extends ASMAnnotatedMember implements ExecutableData {
     @Override
     public ParameterData[] getParameters() {
         ParameterData[] parameterData = new ParameterData[getParameterCount()];
+        List<String> paramNames = extractParameterNames();
+
         for (int i = 0; i < parameterData.length; i++) {
             List<AnnotationNode>[] parameterAnnotations = methodNode.visibleParameterAnnotations;
             List<AnnotationNode> annotationNodes = parameterAnnotations != null ? parameterAnnotations[i] : null;
-            parameterData[i] = new ASMParameter(this, methodNode, i, memberFactory, annotationNodes);
+
+            String paramName = (paramNames != null && i < paramNames.size()) ? paramNames.get(i) : null;
+            parameterData[i] = new ASMParameter(this, methodNode, i, memberFactory, annotationNodes, paramName);
         }
         return parameterData;
+    }
+
+    /**
+     * Extracts parameter names from bytecode LocalVariableTable
+     * LVT doesn't always exist, example abstract methods or methods intended to be overwritten as lambdas.
+     * Falls back to ParameterNode names, then to "arg" + index.
+     * @return list of parameter names
+     */
+    private List<String> extractParameterNames() {
+        if (parameterNames == null) {
+            int paramCount = getParameterCount();
+            Type[] parameterTypes = Type.getType(methodNode.desc).getArgumentTypes();
+            parameterNames = new ArrayList<>(paramCount);
+
+            // Try to get names from LocalVariableTable
+            List<LocalVariableNode> lvt = methodNode.localVariables;
+            if (lvt != null && !lvt.isEmpty()) {
+                int localVariableIndex = (methodNode.access & Opcodes.ACC_STATIC) != 0 ? 0 : 1;
+                for (int i = 0; i < parameterTypes.length && i < paramCount; i++) {
+                    Type parameterType = parameterTypes[i];
+                    String nameFromBytecode = null;
+                    for (LocalVariableNode localVariableNode : lvt) {
+                        if (localVariableNode.index == localVariableIndex) {
+                            nameFromBytecode = localVariableNode.name;
+                            break;
+                        }
+                    }
+                    localVariableIndex += parameterType.getSize();
+                    parameterNames.add(nameFromBytecode != null ? nameFromBytecode : "arg" + i);
+                }
+            } else if (methodNode.parameters != null && methodNode.parameters.size() >= paramCount) {
+                // Fallback to ParameterNode names
+                for (int i = 0; i < paramCount; i++) {
+                    parameterNames.add(methodNode.parameters.get(i).name);
+                }
+            } else {
+                // Last resort: default names
+                for (int i = 0; i < paramCount; i++)
+                    parameterNames.add("arg" + i);
+            }
+
+            // Ensure the list has the correct size by filling up with argX
+            while (parameterNames.size() < paramCount)
+                parameterNames.add("arg" + parameterNames.size());
+        }
+        return parameterNames;
     }
 }

--- a/src/main/java/youyihj/probezs/member/asm/ASMParameter.java
+++ b/src/main/java/youyihj/probezs/member/asm/ASMParameter.java
@@ -15,17 +15,19 @@ public class ASMParameter extends ASMAnnotatedMember implements ParameterData {
     private final MethodNode methodNode;
     private final int index;
     private final ASMMethod method;
+    private final String name;
 
-    public ASMParameter(ASMMethod method, MethodNode methodNode, int index, ASMMemberFactory memberFactory, List<AnnotationNode> annotationNode) {
+    public ASMParameter(ASMMethod method, MethodNode methodNode, int index, ASMMemberFactory memberFactory, List<AnnotationNode> annotationNode, String name) {
         super(annotationNode, memberFactory);
         this.method = method;
         this.methodNode = methodNode;
         this.index = index;
+        this.name = name != null ? name : "arg" + index;
     }
 
     @Override
     public String getName() {
-        return "arg" + index;
+        return name;
     }
 
     @Override

--- a/src/main/java/youyihj/probezs/member/reflection/JavaExecutable.java
+++ b/src/main/java/youyihj/probezs/member/reflection/JavaExecutable.java
@@ -33,7 +33,7 @@ public class JavaExecutable implements ExecutableData {
     }
 
     @Override
-    public Class<?> getDecalredClass() {
+    public Class<?> getDeclaredClass() {
         return executable.getDeclaringClass();
     }
 
@@ -54,7 +54,7 @@ public class JavaExecutable implements ExecutableData {
 
     @Override
     public Type getReturnType() {
-        return executable instanceof Method ? ((Method) executable).getGenericReturnType() : getDecalredClass();
+        return executable instanceof Method ? ((Method) executable).getGenericReturnType() : getDeclaredClass();
     }
 
     @Override

--- a/src/main/java/youyihj/probezs/tree/JavaTypeMirror.java
+++ b/src/main/java/youyihj/probezs/tree/JavaTypeMirror.java
@@ -151,7 +151,10 @@ public class JavaTypeMirror implements Supplier<JavaTypeMirror.Result>, Comparab
         }
 
         static Result missing(ZenClassTree tree, Type originType) {
-            ProbeZS.logger.warn("Do not know zenscript type for {}", originType.getTypeName());
+            if(originType != null)
+                ProbeZS.logger.warn("Do not know zenscript type for {}", originType.getTypeName());
+            else
+                ProbeZS.logger.warn("Do not know zenscript type for null");
             return new MissingResult(tree);
         }
 

--- a/src/main/java/youyihj/probezs/tree/ZenClassNode.java
+++ b/src/main/java/youyihj/probezs/tree/ZenClassNode.java
@@ -402,7 +402,7 @@ public class ZenClassNode implements IZenDumpable, IHasImportMembers, Comparable
 
     private void readExpansionExecutableOwner(ExecutableData method, IMaybeExpansionMember expansionMember) {
         if (ProbeZSConfig.outputSourceExpansionMembers) {
-            String classOwner = ProbeZS.instance.getClassOwner(method.getDecalredClass());
+            String classOwner = ProbeZS.instance.getClassOwner(method.getDeclaredClass());
             expansionMember.setOwner(classOwner);
         }
     }

--- a/src/main/java/youyihj/probezs/tree/global/ZenGlobalMethodNode.java
+++ b/src/main/java/youyihj/probezs/tree/global/ZenGlobalMethodNode.java
@@ -35,7 +35,7 @@ public class ZenGlobalMethodNode extends ZenExecutableNode implements IZenDumpab
         }
         ZenGlobalMethodNode globalMethodNode = new ZenGlobalMethodNode(name, returnType, parameterNodes);
         if (ProbeZSConfig.outputSourceExpansionMembers) {
-            String classOwner = ProbeZS.instance.getClassOwner(method.getDecalredClass());
+            String classOwner = ProbeZS.instance.getClassOwner(method.getDeclaredClass());
             if (!"crafttweaker".equals(classOwner)) {
                 globalMethodNode.setOwner(classOwner);
             }


### PR DESCRIPTION
in the ASM path, we can extract parameter names from the LVT automatically. at least if the LVT exists (not for methods without a body).

also fixed a crash with contentcreator x ASM path

also fixed a typo, kinda whatever